### PR TITLE
Removed start of apache service.

### DIFF
--- a/gbp-patch.sh
+++ b/gbp-patch.sh
@@ -4,7 +4,7 @@ set -x
 
 wget https://raw.githubusercontent.com/group-policy/devstack/sumit/test/stable/juno-gbp/local.conf
 wget https://raw.githubusercontent.com/group-policy/devstack/sumit/test/stable/juno-gbp/lib/gbp -P lib/
-sed -i 's/# Extras Configuration/source $TOP_DIR\/lib\/gbp\ninstall_gbpclient\ninstall_gbpservice\ninit_gbpservice\n\install_gbpheat\ninstall_gbpui\nsudo service apache2 restart\n# Extras Configuration/g' stack.sh
+sed -i 's/# Extras Configuration/source $TOP_DIR\/lib\/gbp\ninstall_gbpclient\ninstall_gbpservice\ninit_gbpservice\n\install_gbpheat\ninstall_gbpui\n# Extras Configuration/g' stack.sh
 sed -i 's/echo_summary "Creating initial neutron network elements"//g' stack.sh
 sed -i 's/create_neutron_initial_network//g' stack.sh
 wget https://raw.githubusercontent.com/group-policy/devstack/sumit/test/stable/juno-gbp/exercises/gbp.sh -P exercises/


### PR DESCRIPTION
The apache start causes the socket bind to fail,
since apache is already running.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
