### PR TITLE
Change image name to cirros-0.3.4-x86_64-uec

### DIFF
--- a/exercises/gbp.sh
+++ b/exercises/gbp.sh
@@ -79,15 +79,15 @@ WEB_PORT=$(gbp policy-target-create web-pt-1 --policy-target-group web | awk "/p
 CLIENT1_PORT=$(gbp policy-target-create client-pt-1 --policy-target-group client-1 | awk "/port_id/ {print \$4}")
 CLIENT2_PORT=$(gbp policy-target-create client-pt-2 --policy-target-group client-2 | awk "/port_id/ {print \$4}")
 
-WEB_VM_1_UUID=`nova boot --flavor m1.tiny --image cirros-0.3.2-x86_64-uec --nic port-id=$WEB_PORT web-vm-1 | grep ' id ' | cut -d"|" -f3 | sed 's/ //g'`
+WEB_VM_1_UUID=`nova boot --flavor m1.tiny --image cirros-0.3.4-x86_64-uec --nic port-id=$WEB_PORT web-vm-1 | grep ' id ' | cut -d"|" -f3 | sed 's/ //g'`
 die_if_not_set $LINENO WEB_VM_1_UUID "Failure launching web-vm-1"
 confirm_server_active $WEB_VM_1_UUID
 
-CLIENT_VM_1_UUID=`nova boot --flavor m1.tiny --image cirros-0.3.2-x86_64-uec --nic port-id=$CLIENT1_PORT client-vm-1 | grep ' id ' | cut -d"|" -f3 | sed 's/ //g'`
+CLIENT_VM_1_UUID=`nova boot --flavor m1.tiny --image cirros-0.3.4-x86_64-uec --nic port-id=$CLIENT1_PORT client-vm-1 | grep ' id ' | cut -d"|" -f3 | sed 's/ //g'`
 die_if_not_set $LINENO CLIENT_VM_1_UUID "Failure launching client-vm-1"
 confirm_server_active $CLIENT_VM_1_UUID
 
-CLIENT_VM_2_UUID=`nova boot --flavor m1.tiny --image cirros-0.3.2-x86_64-uec --nic port-id=$CLIENT2_PORT client-vm-2 | grep ' id ' | cut -d"|" -f3 | sed 's/ //g'`
+CLIENT_VM_2_UUID=`nova boot --flavor m1.tiny --image cirros-0.3.4-x86_64-uec --nic port-id=$CLIENT2_PORT client-vm-2 | grep ' id ' | cut -d"|" -f3 | sed 's/ //g'`
 die_if_not_set $LINENO CLIENT_VM_2_UUID "Failure launching client-vm-2"
 confirm_server_active $CLIENT_VM_2_UUID
 


### PR DESCRIPTION
Presently devstack installs cirros-0.3.4-x86_64-uec but
excercises/gbp.sh expects cirros-0.3.2-x86_64-uec. Hence,
it is apt to change the version.

closes: #3 
